### PR TITLE
Fix storage getSize error

### DIFF
--- a/src/GetId3.php
+++ b/src/GetId3.php
@@ -32,7 +32,7 @@ class GetId3
     {
         return new static(
             $path,
-            Storage::disk($disk)->getSize($path),
+            Storage::disk($disk)->size($path),
             Storage::disk($disk)->readStream($path)
         );
     }


### PR DESCRIPTION
Use `size` instead of `getSize`