### PR TITLE
Add Laravel 13 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "getID3"
     ],
     "require": {
-        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
         "james-heinrich/getid3": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
## Summary
- Added `^13.0` to the `illuminate/support` constraint in `composer.json`
- No breaking changes in Laravel 13 affect this package, so no other modifications are needed

## Test plan
- [x] Verified that no Laravel 13 breaking changes impact this package's codebase
- [x] Confirmed the constraint allows installation alongside Laravel 13